### PR TITLE
perf(verilator): Only rebuild if source files changed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,11 @@ jobs:
       - name: Install verilator
         run: make install_verilator
       - name: Test
-        run: cd verilog-support/example-project && cargo run -p example-verilog-project
+        run: |
+          cd verilog-support/example-project
+          cargo run -p example-verilog-project
+          cargo run -p example-verilog-project # rerun
+      
   test_spade:
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ solutions:
 
 Still, a lot of these are less than optimal.
 
-## 🚀 Showcase
+## ✨ Features
 
 ![Early example of using this with Spade](./assets/demo-alpha.png)
+
+- 🚀 Minimal overhead over directly using `verilator`
+- 🔌 Works completely drop-in in your existing projects
+- 🦀 Rust. Did I say Rust?
 
 ## ⚡️ Requirements
 
@@ -57,7 +61,7 @@ dumbname is currently in development.
 You can currently install the crates via `git` specifications.
 (I'm aware that this is not explained well.)
 
-## ✨ Usage
+## ❓ Usage
 
 I'll write more documentation once I get further in the development process.
 

--- a/verilator/src/lib.rs
+++ b/verilator/src/lib.rs
@@ -290,8 +290,15 @@ fn needs_rebuild(
     source_files: &[&str],
     verilator_artifact_directory: &Utf8Path,
 ) -> Result<bool, Whatever> {
+    if !verilator_artifact_directory.exists() {
+        return Ok(true);
+    }
+
     let Some(last_built) = fs::read_dir(verilator_artifact_directory)
-        .expect("Couldn't access local directory")
+        .whatever_context(format!(
+            "{} exists but could not read it",
+            verilator_artifact_directory
+        ))?
         .flatten() // Remove failed
         .filter_map(|f| {
             if f.metadata()

--- a/verilator/src/lib.rs
+++ b/verilator/src/lib.rs
@@ -286,6 +286,47 @@ extern "C" {{
     Ok(ffi_wrappers)
 }
 
+fn needs_rebuild(
+    source_files: &[&str],
+    verilator_artifact_directory: &Utf8Path,
+) -> Result<bool, Whatever> {
+    let Some(last_built) = fs::read_dir(verilator_artifact_directory)
+        .expect("Couldn't access local directory")
+        .flatten() // Remove failed
+        .filter_map(|f| {
+            if f.metadata()
+                .map(|metadata| metadata.is_file())
+                .unwrap_or(false)
+            {
+                f.metadata().unwrap().modified().ok()
+            } else {
+                None
+            }
+        })
+        .max()
+    else {
+        return Ok(false);
+    };
+
+    for source_file in source_files {
+        let last_edited = fs::metadata(source_file)
+            .whatever_context(format!(
+                "Failed to read file metadata for source file {}",
+                source_file
+            ))?
+            .modified()
+            .whatever_context(format!(
+                "Failed to determine last-modified time for source file {}",
+                source_file
+            ))?;
+        if last_edited > last_built {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
 fn build(
     source_files: &[&str],
     top_module: &str,
@@ -297,6 +338,15 @@ fn build(
         "Failed to create ffi subdirectory under artifacts directory",
     )?;
     let verilator_artifact_directory = artifact_directory.join("obj_dir");
+    let library_name = format!("V{}_dyn", top_module);
+    let library_path =
+        verilator_artifact_directory.join(format!("lib{}.so", library_name));
+
+    if !needs_rebuild(source_files, &verilator_artifact_directory)
+        .whatever_context("Failed to check if artifacts need rebuilding")?
+    {
+        return Ok(library_path);
+    }
 
     let _ffi_wrappers = build_ffi(&ffi_artifact_directory, top_module, ports)
         .whatever_context("Failed to build FFI wrappers")?;
@@ -304,7 +354,6 @@ fn build(
     // bug in verilator#5226 means the directory must be relative to -Mdir
     let ffi_wrappers = Utf8Path::new("../ffi/ffi.cpp");
 
-    let library_name = format!("V{}_dyn", top_module);
     let verilator_output = Command::new("verilator")
         .args(["--cc", "-sv", "--build", "-j", "0"])
         .args(["-CFLAGS", "-shared -fpic"])
@@ -326,5 +375,5 @@ fn build(
         );
     }
 
-    Ok(verilator_artifact_directory.join(format!("lib{}.so", library_name)))
+    Ok(library_path)
 }


### PR DESCRIPTION
We only need to reinvoke verilator when source files have changed.