### PR TITLE
fix(spade): Ensure logos version matches that used in Spade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c426b7af8d5e0ad79de6713996632ce31f0d68ba84068fb0d654b396e519df0"
 dependencies = [
- "colored",
+ "colored 2.2.0",
  "env_logger",
  "log",
 ]
@@ -134,6 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
  "windows-sys",
 ]
 
@@ -210,9 +219,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -258,18 +267,18 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "logos"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
+checksum = "ab6f536c1af4c7cc81edf73da1f8029896e7e1e16a219ef09b184e76a296f3db"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-codegen"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
+checksum = "189bbfd0b61330abea797e5e9276408f2edbe4f822d7ad08685d67419aafb34e"
 dependencies = [
  "beef",
  "fnv",
@@ -277,14 +286,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
+ "rustc_version",
  "syn 2.0.96",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
+checksum = "ebfe8e1a19049ddbfccbd14ac834b215e11b85b90bab0c2dba7c7b92fb5d5cba"
 dependencies = [
  "logos-codegen",
 ]
@@ -529,6 +539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +555,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -592,7 +617,7 @@ dependencies = [
 [[package]]
 name = "spade-ast"
 version = "0.12.0"
-source = "git+https://gitlab.com/spade-lang/spade#79cfd7ed12ee8a7328aa6e6650e394ed55ed2b2c"
+source = "git+https://gitlab.com/ethanuppal/spade?branch=hotfixlogos#b5dec55034fb0fa355639cc93a9cf44dd10c74fa"
 dependencies = [
  "itertools",
  "num",
@@ -602,7 +627,7 @@ dependencies = [
 [[package]]
 name = "spade-common"
 version = "0.12.0"
-source = "git+https://gitlab.com/spade-lang/spade#79cfd7ed12ee8a7328aa6e6650e394ed55ed2b2c"
+source = "git+https://gitlab.com/ethanuppal/spade?branch=hotfixlogos#b5dec55034fb0fa355639cc93a9cf44dd10c74fa"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -614,7 +639,7 @@ dependencies = [
 [[package]]
 name = "spade-diagnostics"
 version = "0.12.0"
-source = "git+https://gitlab.com/spade-lang/spade#79cfd7ed12ee8a7328aa6e6650e394ed55ed2b2c"
+source = "git+https://gitlab.com/ethanuppal/spade?branch=hotfixlogos#b5dec55034fb0fa355639cc93a9cf44dd10c74fa"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -627,7 +652,6 @@ name = "spade-macro"
 version = "0.0.0"
 dependencies = [
  "camino",
- "logos",
  "proc-macro2",
  "quote",
  "spade-ast",
@@ -640,7 +664,7 @@ dependencies = [
 [[package]]
 name = "spade-macros"
 version = "0.12.0"
-source = "git+https://gitlab.com/spade-lang/spade#79cfd7ed12ee8a7328aa6e6650e394ed55ed2b2c"
+source = "git+https://gitlab.com/ethanuppal/spade?branch=hotfixlogos#b5dec55034fb0fa355639cc93a9cf44dd10c74fa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -650,10 +674,10 @@ dependencies = [
 [[package]]
 name = "spade-parser"
 version = "0.12.0"
-source = "git+https://gitlab.com/spade-lang/spade#79cfd7ed12ee8a7328aa6e6650e394ed55ed2b2c"
+source = "git+https://gitlab.com/ethanuppal/spade?branch=hotfixlogos#b5dec55034fb0fa355639cc93a9cf44dd10c74fa"
 dependencies = [
  "codespan",
- "colored",
+ "colored 3.0.0",
  "itertools",
  "local-impl",
  "logos",
@@ -662,7 +686,6 @@ dependencies = [
  "spade-common",
  "spade-diagnostics",
  "spade-macros",
- "thiserror",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ proc-macro2 = "1.0.93"
 syn = { version = "2.0.96", features = ["full"] }
 quote = "1.0.38"
 sv-parser = "0.13.3"
-logos = "0.14.4"
+spade-parser = { git = "https://gitlab.com/ethanuppal/spade", branch = "hotfixlogos" } #, rev = "0c96a2248fe80b550430be86d3efc1dc9cd15c6f" }
+spade-ast = { git = "https://gitlab.com/ethanuppal/spade", branch = "hotfixlogos" }    #, rev = "0c96a2248fe80b550430be86d3efc1dc9cd15c6f" }
 log = "0.4.25"
 colog = "1.3.0"
 

--- a/spade-support/spade-macro/Cargo.toml
+++ b/spade-support/spade-macro/Cargo.toml
@@ -21,6 +21,5 @@ proc-macro2.workspace = true
 syn.workspace = true
 quote.workspace = true
 
-logos.workspace = true
-spade-parser = { git = "https://gitlab.com/spade-lang/spade" }
-spade-ast = { git = "https://gitlab.com/spade-lang/spade" }
+spade-parser.workspace = true
+spade-ast.workspace = true

--- a/spade-support/spade-macro/src/lib.rs
+++ b/spade-support/spade-macro/src/lib.rs
@@ -69,7 +69,7 @@ pub fn spade(args: TokenStream, item: TokenStream) -> TokenStream {
     let mut parser = spade_parser::Parser::new(lexer, 0);
     let top_level = match parser.top_level_module_body() {
         Ok(body) => body,
-        Err(error) => {
+        Err(_error) => {
             return syn::Error::new_spanned(
                 args.source_path,
                 "Failed to parse Spade code: run the Spade compiler for more details",

--- a/spade-support/spade-macro/src/lib.rs
+++ b/spade-support/spade-macro/src/lib.rs
@@ -7,8 +7,8 @@
 use std::{env, fs};
 
 use camino::Utf8PathBuf;
-use logos::Logos;
 use proc_macro::TokenStream;
+use spade_parser::Logos;
 use verilator::PortDirection;
 use verilog_macro_builder::{build_verilated_struct, MacroArgs};
 
@@ -65,14 +65,14 @@ pub fn spade(args: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    let lexer = spade_parser::lexer::TokenKind::lexer(&source_code);
+    let lexer = <spade_parser::lexer::TokenKind as Logos>::lexer(&source_code);
     let mut parser = spade_parser::Parser::new(lexer, 0);
     let top_level = match parser.top_level_module_body() {
         Ok(body) => body,
         Err(error) => {
             return syn::Error::new_spanned(
                 args.source_path,
-                error.to_string(),
+                "Failed to parse Spade code: run the Spade compiler for more details",
             )
             .into_compile_error()
             .into();


### PR DESCRIPTION
We've been lucky so far in that the logos versions haven't diverged, but since Spade doesn't reexport the logos it uses, there would inevitably be a problem.

That day has come, so this is a hotfix that now uses my Spade fork which reexports logos.